### PR TITLE
Adds a build matrix for supported Go versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,18 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     # A matrix proves the supported range of Go versions work. This must always
     # include the floor Go version policy of Mosn and the current Go version.
-    # Mosn binaries are built with a specific version inside this range. Mosn's
-    # floor Go version is two behind current. For example, if Go supports 1.20,
-    # Mosn supports 1.18, 1.19 and 1.20.
+    # Mosn's floor Go version for libraries is two behind current, e.g. if Go
+    # supports 1.19 and 1.20, Mosn libraries must work on 1.18, 1.19 and 1.20.
     #
     # A floor version is required to ensure Mosn can receive security patches.
     # Without one, dependencies become locked to an old version of Go, which
     # itself receives no security patch updates.
     #
-    # Note: Mosn might work with a Go version below its supported floor, but
-    # users must not depend on this. Mosn and its library dependencies are free
-    # to use features in the supported floor Go version at any time. This
-    # remains true even if mosn library dependencies are not eagerly updated.
+    # Mosn's binary is built with Go's floor version, e.g. if Go supports 1.19
+    # and 1.20, Mosn will build any downloadable executables with 1.19.
+    #
+    # Even if mosn works with a Go version below its supported floor, users
+    # must not depend on this. Mosn and its library dependencies are free to
+    # use features in the supported floor Go version at any time. This remains
+    # true even if mosn library dependencies are not eagerly updated.
     #
     # Note: There are no unit tests in this project, so we run a matrix on
     # build, not test.
@@ -28,6 +30,7 @@ jobs:
       matrix:
         go-version:
           - "1.19"  # Current Go version
+          - "1.18"
           - "1.17"  # Floor Go version of Mosn == current - 2
 
     steps:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     # A matrix proves the supported range of Go versions work. This must always
     # include the floor Go version policy of Mosn and the current Go version.
-    # Mosn binaries are built with a specific version inside this range.
+    # Mosn binaries are built with a specific version inside this range. Mosn's
+    # floor Go version is two behind current. For example, if Go supports 1.20,
+    # Mosn supports 1.18, 1.19 and 1.20.
     #
     # A floor version is required to ensure Mosn can receive security patches.
     # Without one, dependencies become locked to an old version of Go, which
@@ -24,8 +26,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
           - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of Mosn == current - 2
 
     steps:
       - name: Check out code

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,8 +18,9 @@ jobs:
     # itself receives no security patch updates.
     #
     # Note: Mosn might work with a Go version below its supported floor, but
-    # users must not depend on this. Mosn's library dependencies are free to
-    # features in it supported floor Go version at any time.
+    # users must not depend on this. Mosn and its library dependencies are free
+    # to use features in the supported floor Go version at any time. This
+    # remains true even if mosn library dependencies are not eagerly updated.
     #
     # Note: There are no unit tests in this project, so we run a matrix on
     # build, not test.

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,6 +7,26 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A matrix proves the supported range of Go versions work. This must always
+    # include the floor Go version policy of Mosn and the current Go version.
+    # Mosn binaries are built with a specific version inside this range.
+    #
+    # A floor version is required to ensure Mosn can receive security patches.
+    # Without one, dependencies become locked to an old version of Go, which
+    # itself receives no security patch updates.
+    #
+    # Note: Mosn might work with a Go version below its supported floor, but
+    # users must not depend on this. Mosn's library dependencies are free to
+    # features in it supported floor Go version at any time.
+    #
+    # Note: There are no unit tests in this project, so we run a matrix on
+    # build, not test.
+    strategy:
+      matrix:
+        go-version:
+          - "1.18"
+          - "1.19"  # Current Go version
+
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -14,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.go-version }}
           cache: true
 
       - name: Build


### PR DESCRIPTION
This is an attempt to establish a Go version policy while also reminding people why this is important. There's no way without testing version ranges that maintainers can have confidence that very old version of Go will continue to compile.

Please advise if the supported floor should be less than 1.18, noting realities may force this to be higher than you think. For example, build flags that check for at least go 1.11 are invalid because go 1.10 cannot build mosn anymore due to core dependencies requiring a higher version.

cc @taoyuanyuan @antJack

See https://github.com/mosn/mosn/issues/2153