### PR TITLE
metrics support for creating EWMA

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Metrics is a wrapper interface for go-metrics
-// support Counter, Gauge Histogram
+// support Counter, Gauge, Histogram, EWMA
 type Metrics interface {
 	// Type returns metrics logical type, e.g. 'downstream'/'upstream', this is more like the Subsystem concept
 	Type() string
@@ -46,6 +46,11 @@ type Metrics interface {
 	// Histogram creates or returns a go-metrics histogram by key
 	// if the key is registered by other interface, it will be panic
 	Histogram(key string) metrics.Histogram
+
+	// EWMA creates or returns a go-metrics ewma by key
+	// if the key is registered by other interface, it will be panic.
+	// See: https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+	EWMA(key string, alpha float64) metrics.EWMA
 
 	// Each call the given function for each registered metric.
 	Each(func(string, interface{}))


### PR DESCRIPTION
The current Histogram time complexity is O(n) (n is the number of samples), which is not suitable for the core path. In order to improve the time efficiency and accuracy of calculating latency features, we plan to calculate feature values ​​​​through EWMA in quasi-real time. 
The associated Issue is https://github.com/mosn/mosn/issues/2252